### PR TITLE
iOS 14: back button disappears - FIX

### DIFF
--- a/iOS/CIFilter.io/AppDelegate.swift
+++ b/iOS/CIFilter.io/AppDelegate.swift
@@ -50,7 +50,7 @@ class SceneDelegate: NSObject, UISceneDelegate {
         let navController = UINavigationController(rootViewController: filterListViewController)
         navController.navigationBar.prefersLargeTitles = true
 
-        let detailViewController = FilterDetailViewController(splitViewController: splitViewController)
+        let detailViewController = FilterDetailViewController()
         let detailNavController = UINavigationController(rootViewController: detailViewController)
         splitViewController.viewControllers = [navController, detailNavController]
         filterListViewController.didTapFilterInfo.sink { info in

--- a/iOS/CIFilter.io/AppDelegate.swift
+++ b/iOS/CIFilter.io/AppDelegate.swift
@@ -50,7 +50,7 @@ class SceneDelegate: NSObject, UISceneDelegate {
         let navController = UINavigationController(rootViewController: filterListViewController)
         navController.navigationBar.prefersLargeTitles = true
 
-        let detailViewController = FilterDetailViewController()
+        let detailViewController = FilterDetailViewController(splitViewController: splitViewController)
         let detailNavController = UINavigationController(rootViewController: detailViewController)
         splitViewController.viewControllers = [navController, detailNavController]
         filterListViewController.didTapFilterInfo.sink { info in

--- a/iOS/CIFilter.io/Filter Detail/FilterDetailViewController.swift
+++ b/iOS/CIFilter.io/Filter Detail/FilterDetailViewController.swift
@@ -10,20 +10,15 @@ import Foundation
 import SwiftUI
 
 final class FilterDetailViewController: UIHostingController<FilterDetailSwiftUIView> {
-    init() {
+    init(splitViewController: UISplitViewController) {
         super.init(rootView: FilterDetailSwiftUIView(filterInfo: nil, didTapTryIt: { }, didTapShare: { }))
+        self.navigationItem.leftBarButtonItem = splitViewController.displayModeButtonItem
+        self.navigationItem.leftItemsSupplementBackButton = true
         self.navigationItem.largeTitleDisplayMode = .never
     }
 
     @objc required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        self.navigationItem.leftBarButtonItem = splitViewController?.displayModeButtonItem
-        self.navigationItem.leftItemsSupplementBackButton = true
     }
 
     func presentShareSheet(filterInfo: FilterInfo) {

--- a/iOS/CIFilter.io/Filter Detail/FilterDetailViewController.swift
+++ b/iOS/CIFilter.io/Filter Detail/FilterDetailViewController.swift
@@ -10,15 +10,20 @@ import Foundation
 import SwiftUI
 
 final class FilterDetailViewController: UIHostingController<FilterDetailSwiftUIView> {
-    init(splitViewController: UISplitViewController) {
+    init() {
         super.init(rootView: FilterDetailSwiftUIView(filterInfo: nil, didTapTryIt: { }, didTapShare: { }))
-        self.navigationItem.leftBarButtonItem = splitViewController.displayModeButtonItem
-        self.navigationItem.leftItemsSupplementBackButton = true
         self.navigationItem.largeTitleDisplayMode = .never
     }
 
     @objc required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        self.navigationItem.leftBarButtonItem = splitViewController?.displayModeButtonItem
+        self.navigationItem.leftItemsSupplementBackButton = true
     }
 
     func presentShareSheet(filterInfo: FilterInfo) {


### PR DESCRIPTION
Issue https://github.com/noahsark769/cifilter.io/issues/132

Putting the `displayModeButtonItem` in `viewDidLoad` got rid of the flash. Good call! 

I kept the `largeTitleDisplayMode` assignment in the initializer for a smooth transition. Setting that in `viewDidLoad` caused a visual hiccup.

Thanks for creating this project! It's been really helpful.