### PR TITLE
Remove pod spec url

### DIFF
--- a/iOS/Podfile
+++ b/iOS/Podfile
@@ -2,8 +2,6 @@ platform :ios, '13.0'
 workspace 'CIFilter.io'
 project 'CIFilter.io.xcodeproj'
 
-source 'https://github.com/CocoaPods/Specs'
-
 use_frameworks!
 
 def shared_pods


### PR DESCRIPTION
It seems this is no longer needed, and causes an error when running 'pod install'.

Thanks so much for open-sourcing this project!